### PR TITLE
Added DoddleReport Github url and deprecated Codeplex url

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,12 @@ A simple object mapper for .Net.
 
 ## DoddleReport
 
-<sup><del>GitHub</del> [CodePlex][doddlereport-gh]</sup> <sup>[NuGet][doddlereport-nuget]</sup>
+<sup>[GitHub][doddlereport-gh]</sup> <sup><del>[CodePlex][doddlereport-cp]</del></sup> <sup>[NuGet][doddlereport-nuget]</sup>
 
 DoddleReport generates tabular reports from any IEnumerable datasource.
 
-[doddlereport-gh]:    http://doddlereport.codeplex.com
+[doddlereport-gh]:    https://github.com/matthidinger/DoddleReport
+[doddlereport-cp]:    http://doddlereport.codeplex.com
 [doddlereport-nuget]: https://www.nuget.org/packages/DoddleReport
 
 ## [DotVVM]


### PR DESCRIPTION
Hi, really like this resource and thought I would update the URL for DoddleReport from CodePlex to reflect the migration to GitHub.